### PR TITLE
Update example: choose a running exit which allows the desired port

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ OR
 
     circ.create()
     // .. optionally more extends ..
-    circ.extend(con.getORWithFlag("Exit");
+    // circ.extend(con.getORWithFlag("Running");
+    circ.extend(con.getORWithFlag("Exit,Running".split(","), port);
     
 
 Once you've got a circuit built, you can create a TorStream:


### PR DESCRIPTION
Checking the exit policy (albeit inaccurately) increases the success rate of createStream from around 50% to around 90%.
Also demonstrate how to choose running relay(s), if desired.
Simplify from RandomRouteExample by dropping the "Valid" flag.
